### PR TITLE
🏷️ Add label-gate workflow wrapper for org compliance

### DIFF
--- a/.github/workflows/label-gate-wrapper.yml
+++ b/.github/workflows/label-gate-wrapper.yml
@@ -1,0 +1,15 @@
+name: Label Gate Wrapper
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  trigger-label-gate:
+    name: Trigger Organization Label Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call org-wide label gate
+        uses: Mert-s-LUNA-INC/.github/.github/workflows/label-gate.yml@main
+        with:
+          READY_LABEL: 'ready-for-review'


### PR DESCRIPTION
## Description
This PR adds a wrapper workflow to comply with the organization's label gate standards.

## Why this change?
As part of org-wide GitHub standards enforcement, all repositories need to implement a label gate workflow to ensure pull requests are properly reviewed before merging.

## What does this do?
- Adds `.github/workflows/label-gate-wrapper.yml` that calls the org-wide label gate workflow
- Enforces that PRs must have a `ready-for-review` label before they can be merged
- Helps maintain consistent review practices across the organization

## Testing
- [ ] Workflow syntax has been validated
- [ ] Compatible with org-wide workflow at `Mert-s-LUNA-INC/.github`

## Labels needed
This PR itself will need the `ready-for-review` label to be merged once the workflow is active.

## Note
🛡️ This is part of the organization's governance and compliance automation initiative.